### PR TITLE
[dev] PBI AB#114211 [Back Office] Update Service Companion builder to use new Saddleback icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hc-app-icons",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "main": "./dist/generated/",
     "types": "dist/types/index.d.ts",
     "typesVersions": {

--- a/src/v2/icons/qr-code-solid.svg
+++ b/src/v2/icons/qr-code-solid.svg
@@ -2,9 +2,6 @@
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 25 24">
   <defs>
     <style>
-      .cls-1 {
-        mask: url(#mask);
-      }
 
       .cls-2 {
         fill: #d9d9d9;
@@ -14,11 +11,6 @@
         fill: #333;
       }
     </style>
-    <mask id="mask" x=".5" y="0" width="24" height="24" maskUnits="userSpaceOnUse">
-      <g id="mask0_2274_36688" data-name="mask0 2274 36688">
-        <rect class="cls-2" x=".5" y="0" width="24" height="24"/>
-      </g>
-    </mask>
   </defs>
   <g class="cls-1">
     <path class="cls-3" d="M3.22,11V2.73h8.28v8.27H3.22ZM5.5,8.73h3.72v-3.72h-3.72v3.72ZM3.22,21.27v-8.27h8.28v8.27H3.22ZM5.5,19h3.72v-3.73h-3.72v3.73ZM13.5,11V2.73h8.28v8.27h-8.28ZM15.77,8.73h3.72v-3.72h-3.72v3.72ZM19.71,21.27v-2.07h2.07v2.07h-2.07ZM13.5,15.07v-2.07h2.07v2.07h-2.07ZM15.57,17.14v-2.07h2.07v2.07h-2.07ZM13.5,19.2v-2.07h2.07v2.07h-2.07ZM15.57,21.27v-2.07h2.07v2.07h-2.07ZM17.64,19.2v-2.07h2.07v2.07h-2.07ZM17.64,15.07v-2.07h2.07v2.07h-2.07ZM19.71,17.14v-2.07h2.07v2.07h-2.07Z"/>


### PR DESCRIPTION
Fixed the `qr-code-solid.svg`, which contained a mask that caused an invalid SVG to be generated.